### PR TITLE
docs: fix invokefunction calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,11 +286,11 @@ At this point your ‘Hello World’ contract is deployed and could be invoked. 
 #### Step 7
 Invoke contract.
 ```
-$ ./bin/neo-go contract invokefunction -e http://localhost:20331 -w my_wallet.json -g 0.00001 6d1eeca891ee93de2b7a77eb91c26f3b3c04d6cf
+$ ./bin/neo-go contract invoke -e http://localhost:20331 -w my_wallet.json -g 0.00001 6d1eeca891ee93de2b7a77eb91c26f3b3c04d6cf
 ```
 
 Where
-- `contract invokefunction` runs invoke with provided parameters
+- `contract invoke` runs invoke with provided parameters
 - `-e http://localhost:20331` defines RPC endpoint used for function call
 - `-w my_wallet.json` is a wallet
 - `-g 0.00001` defines amount of GAS to be used for invoke operation
@@ -479,7 +479,7 @@ Which means that our contract was deployed and now we can invoke it.
 Let's invoke our contract. As far as we have never invoked this contract, there's no value in the storage, so the contract should create a new one (which is `1`) and put it into storage.
 Let's check:
 ```
-./bin/neo-go contract invokefunction -e http://localhost:20331 -w my_wallet.json -g 0.00001 85cf2075f3e297d489ff3c4c1745ca80d44e2a68
+./bin/neo-go contract invoke -e http://localhost:20331 -w my_wallet.json -g 0.00001 85cf2075f3e297d489ff3c4c1745ca80d44e2a68
 ```
 ... enter the password `qwerty`:
 ```
@@ -567,7 +567,7 @@ which is the counter value denoted to the number of contract invocations.
 #### Step #4
 To ensure that all works as expected, let's invoke the contract one more time and check, whether the counter will be incremented: 
 ```
-./bin/neo-go contract invokefunction -e http://localhost:20331 -w my_wallet.json -g 0.00001 85cf2075f3e297d489ff3c4c1745ca80d44e2a68
+./bin/neo-go contract invoke -e http://localhost:20331 -w my_wallet.json -g 0.00001 85cf2075f3e297d489ff3c4c1745ca80d44e2a68
 ```
 ... enter the password `qwerty`:
 ```

--- a/README.ru.md
+++ b/README.ru.md
@@ -282,11 +282,11 @@ Sent deployment transaction ea93196802fe3517d2d028e4d4f244aa734a9b1988456740d96f
 #### Шаг 7
 Вызовите контракт.
 ```
-$ ./bin/neo-go contract invokefunction -e http://localhost:20331 -w my_wallet.json -g 0.00001 6d1eeca891ee93de2b7a77eb91c26f3b3c04d6cf
+$ ./bin/neo-go contract invoke -e http://localhost:20331 -w my_wallet.json -g 0.00001 6d1eeca891ee93de2b7a77eb91c26f3b3c04d6cf
 ```
 
 Где
-- `contract invokefunction` запускает вызов контракта с заданными параметрами
+- `contract invoke` запускает вызов контракта с заданными параметрами
 - `-e http://localhost:20331` определяет эндпоинт RPC, используемый для вызова функции
 - `-w my_wallet.json` - бумажник
 - `-g 0.00001` определяет количество газа, которое будет использовано для вызова смарт-контракта
@@ -474,7 +474,7 @@ Sent deployment transaction d79e5e39d87c2911b623d3efe98842cfde41eddc34d85cee3947
 Поскольку мы не вызывали наш смарт-контракт раньше, в его хранилище нет никаких значений, поэтому при первом вызове он должен создать новое значение (равное `1`) и положить его в хранилище.
 Давайте проверим:
 ```
-./bin/neo-go contract invokefunction -e http://localhost:20331 -w my_wallet.json -g 0.00001 85cf2075f3e297d489ff3c4c1745ca80d44e2a68
+./bin/neo-go contract invoke -e http://localhost:20331 -w my_wallet.json -g 0.00001 85cf2075f3e297d489ff3c4c1745ca80d44e2a68
 ```
 ... введите пароль `qwerty`:
 ```
@@ -562,7 +562,7 @@ curl -d '{ "jsonrpc": "2.0", "id": 1, "method": "getapplicationlog", "params": [
 #### Шаг #4
 Для того чтобы убедиться, что все работает как надо, давайте вызовем наш контракт еще раз и проверим, что счетчик будет увеличен: 
 ```
-./bin/neo-go contract invokefunction -e http://localhost:20331 -w my_wallet.json -g 0.00001 85cf2075f3e297d489ff3c4c1745ca80d44e2a68
+./bin/neo-go contract invoke -e http://localhost:20331 -w my_wallet.json -g 0.00001 85cf2075f3e297d489ff3c4c1745ca80d44e2a68
 ```
 ... введите пароль `qwerty`:
 ```


### PR DESCRIPTION
After https://github.com/nspcc-dev/neo-go/pull/848 we'll have an error
when calling `invokefunction` without method, like in `1-print.go` and
`2-storage.go` examples. Updated docs to call `invoke` instead of
`invokefunction` in these contracts as far as we don't have parameters
for these calls.